### PR TITLE
Target Python 3.14 across tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ These commands cover clang-format, clang-tidy, cpplint, and Ruff. If you intenti
 ### Python Environment Notes
 
 - uv manages the `.venv` automatically; avoid committing it.
-- Prefer Python 3.11 for now. uv pins compatible wheels for SystemC/PySysC integration.
+- Prefer Python 3.14 for now. uv pins compatible wheels for SystemC/PySysC integration.
 - Install the Xcode Command Line Tools (`xcode-select --install`). Invoke tasks set `CC=/usr/bin/clang` and `CXX=/usr/bin/clang++` so the Apple-provided SDK-aware toolchain is used when compiling SystemC.
 
 ## Clean Code Principles

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ ARG USER_UID=1000
 ARG USER_GID=1000
 
 ################################################################################
-# Base stage — compiler toolchain, Python 3.11, uv, Invoke deps.
+# Base stage — compiler toolchain, Python 3.14, uv, Invoke deps.
 ################################################################################
-FROM python:3.11-bookworm AS base
+FROM python:3.14-bookworm AS base
 ARG USERNAME
 ARG USER_UID
 ARG USER_GID
@@ -117,7 +117,7 @@ RUN CMAKE_PREFIX_PATH=${TOYSSD_SYSTEMC_PREFIX} \
 ################################################################################
 # Runtime stage — slim image for executing workloads.
 ################################################################################
-FROM python:3.11-slim AS runtime
+FROM python:3.14-slim AS runtime
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ### Prerequisites
 
-- Python 3.11+ (uv will set up a local virtual environment automatically).
+- Python 3.14+ (uv will set up a local virtual environment automatically).
 - Xcode Command Line Tools (`xcode-select --install`) so Apple’s SDK-aware Clang and system headers are available.
 - CMake ≥ 3.24 and a C++20-capable compiler. Invoke tasks pin `CC=/usr/bin/clang` and `CXX=/usr/bin/clang++` so the Apple Clang toolchain is used by default.
 - Ninja (optional but preferred for faster builds; uv/scikit-build-core will fetch it if missing).

--- a/docs/docker_design.md
+++ b/docs/docker_design.md
@@ -17,7 +17,7 @@ This document defines the Docker-based development and runtime architecture for 
 
 | Stage     | Purpose                      | Includes                                                                 |
 | --------- | ---------------------------- | ------------------------------------------------------------------------ |
-| `base`    | Foundation image             | OS packages, Python 3.11, LLVM/Clang toolchain, official `uv` binary     |
+| `base`    | Foundation image             | OS packages, Python 3.14, LLVM/Clang toolchain, official `uv` binary     |
 | `dev`     | Full development environment | `/opt/systemc`, PySysC headers, CMake/Ninja, Invoke tasks, VS Code hooks |
 | `runtime` | Slim image for end-users     | Python runtime + toyssd wheel/stub backend + SystemC runtime libraries   |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ description = "Modular SSD simulator skeleton backed by SystemC"
 # Long-form documentation to display on package pages
 readme = "docs/ssd_sim_design.md"
 # Support modern Python features and type hints; also narrows the wheel targets
-requires-python = ">=3.10"
+requires-python = ">=3.14"
 # Authors are optional but helpful for provenance and support
 authors = [
   { name = "toyssd contributors" }
@@ -68,11 +68,11 @@ toyssd = { path = "python", editable = true }
 [tool.scikit-build]
 # Minimum scikit-build-core version features we rely on
 minimum-version = "0.7"
-# Wheel Python ABI tag. "cp311" produces a CPython-3.11-specific wheel,
+# Wheel Python ABI tag. "cp314" produces a CPython-3.14-specific wheel,
 # which can improve compatibility with compiled extensions at the cost of
 # being version-specific.
 # TODO: Omit this or use a more generic tag per scikit-build-core docs.
-wheel.py-api = "cp311"
+wheel.py-api = "cp314"
 # Pass through a CMake cache definition. Default tests OFF to speed CI
 # builds of wheels and avoid bundling test-only artifacts. Override at
 # build time with: `-C cmake.define.TOYSSD_BUILD_TESTS=ON`.
@@ -86,7 +86,7 @@ addopts = "-q"
 
 [tool.mypy]
 # Static type checking settings. Target our main dev Python version for stubs.
-python_version = "3.11"
+python_version = "3.14"
 # Many third-party packages lack type hints; ignoring missing imports avoids noise.
 ignore_missing_imports = true
 # Start with non-strict to ease adoption; tighten as the project grows.


### PR DESCRIPTION
## Summary
- update the Docker base and runtime images to Python 3.14
- refresh contributor and README guidance to call out Python 3.14 as the baseline
- retarget packaging metadata (requires-python, wheel ABI tag, mypy) for CPython 3.14

## Testing
- uv run --python 3.14 invoke format
- uv run --python 3.14 invoke lint
- uv run --python 3.14 invoke build
- uv run --python 3.14 invoke test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69112457ab8c832c86e97531650959e3)